### PR TITLE
Ignore errors caused by subscribers trying to access nonexistent registry records when package is still not installed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,10 +4,12 @@ Changelog
 1.0a2 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Ignore errors caused by subscribers trying to access nonexistent registry records when package is still not installed (fixes `#1`_).
+  [hvelarde]
 
 1.0a1 (2015-06-08)
 ------------------
 
 - Initial release.
+
+.. _`#1`: https://github.com/collective/collective.fingerpointing/issues/1

--- a/src/collective/fingerpointing/subscribers/lifecycle_logger.py
+++ b/src/collective/fingerpointing/subscribers/lifecycle_logger.py
@@ -4,6 +4,7 @@ from collective.fingerpointing.interfaces import IFingerPointingSettings
 from collective.fingerpointing.logger import logger
 from collective.fingerpointing.utils import get_request_information
 from plone import api
+from plone.api.exc import InvalidParameterError
 from zope.lifecycleevent import IObjectCreatedEvent
 from zope.lifecycleevent import IObjectModifiedEvent
 from zope.lifecycleevent import IObjectRemovedEvent
@@ -13,8 +14,15 @@ def lifecycle_logger(obj, event):
     """Log content type life cycle events like object creation,
     modification and removal.
     """
-    record = IFingerPointingSettings.__identifier__ + '.audit_lifecycle'
-    if api.portal.get_registry_record(record):
+    # subscriber is registered even if package has not yet been installed
+    # ignore any error caused by missing registry records
+    try:
+        record = IFingerPointingSettings.__identifier__ + '.audit_lifecycle'
+        audit_lifecycle = api.portal.get_registry_record(record)
+    except InvalidParameterError:
+        return
+
+    if audit_lifecycle:
         user, ip = get_request_information()
 
         if IObjectCreatedEvent.providedBy(event):

--- a/src/collective/fingerpointing/subscribers/pas_logger.py
+++ b/src/collective/fingerpointing/subscribers/pas_logger.py
@@ -4,6 +4,7 @@ from collective.fingerpointing.interfaces import IFingerPointingSettings
 from collective.fingerpointing.logger import logger
 from collective.fingerpointing.utils import get_request_information
 from plone import api
+from plone.api.exc import InvalidParameterError
 from Products.PluggableAuthService.interfaces.events import IPrincipalCreatedEvent
 from Products.PluggableAuthService.interfaces.events import IPrincipalDeletedEvent
 from Products.PluggableAuthService.interfaces.events import IUserLoggedInEvent
@@ -12,8 +13,15 @@ from Products.PluggableAuthService.interfaces.events import IUserLoggedOutEvent
 
 def pas_logger(event):
     """Log authentication events like users logging in and loggin out."""
-    record = IFingerPointingSettings.__identifier__ + '.audit_pas'
-    if api.portal.get_registry_record(record):
+    # subscriber is registered even if package has not yet been installed
+    # ignore any error caused by missing registry records
+    try:
+        record = IFingerPointingSettings.__identifier__ + '.audit_pas'
+        audit_pas = api.portal.get_registry_record(record)
+    except InvalidParameterError:
+        return
+
+    if audit_pas:
         user, ip = get_request_information()
 
         if IUserLoggedInEvent.providedBy(event):

--- a/src/collective/fingerpointing/tests/test_lifecycle_subscriber.py
+++ b/src/collective/fingerpointing/tests/test_lifecycle_subscriber.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from collective.fingerpointing.config import PROJECTNAME
 from collective.fingerpointing.testing import INTEGRATION_TESTING
 from logging import INFO
 from plone import api
@@ -35,3 +36,14 @@ class LifeCycleSubscribersTestCase(unittest.TestCase):
                 ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=object removed object=<ATFolder at foo>'),
                 ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=object modified object=<ATFolder at folder>'),
             )
+
+    def test_susbcriber_ignored_when_package_not_installed(self):
+        # content type life cycle events should not raise errors
+        # if package is not installed
+        qi = self.portal['portal_quickinstaller']
+
+        with api.env.adopt_roles(['Manager']):
+            qi.uninstallProducts(products=[PROJECTNAME])
+
+        api.content.create(self.folder, 'Folder', 'foo')
+        api.content.delete(self.folder['foo'])


### PR DESCRIPTION
closes #1 