### PR TITLE
Add support for configuring an extra logfile.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.0a2 (unreleased)
 ------------------
 
+- Audit information is now logged into a file named `audit.log` instead of inside the standard `event.log`.
+  [jochum]
+
 - Ignore errors caused by subscribers trying to access nonexistent registry records when package is still not installed (fixes `#1`_).
   [hvelarde]
 

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -28,6 +28,7 @@ flake8-extensions =
     flake8-coding
     flake8-debugger
     flake8-deprecated
+#    flake8-isort
 #    flake8-quotes
 
 [i18ndude]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[settings]
+[isort]
 force_alphabetical_sort = True
 force_single_line = True
 lines_after_imports = 2

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
         'zope.interface',
         'zope.lifecycleevent',
         'zope.schema',
+        'zc.lockfile',
     ],
     extras_require={
         'test': [

--- a/src/collective/fingerpointing/config.py
+++ b/src/collective/fingerpointing/config.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
 PROJECTNAME = 'collective.fingerpointing'
 
+AUDITLOG = 'audit.log'
 AUDIT_MESSAGE = 'user={0} ip={1} action={2} {3}'
+LOGFORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'

--- a/src/collective/fingerpointing/logger.py
+++ b/src/collective/fingerpointing/logger.py
@@ -1,5 +1,53 @@
 # -*- coding: utf-8 -*-
+from App.config import getConfiguration
+from collective.fingerpointing.config import AUDITLOG
+from collective.fingerpointing.config import LOGFORMAT
 from collective.fingerpointing.config import PROJECTNAME
+
 import logging
+import os.path
+import time
+import zc.lockfile
+
+# by default, the audit log will use the same location used for the event log
+eventlog = getattr(getConfiguration(), 'eventlog', None)
+
+# on tests, eventlog is not set; we need to handle that
+if eventlog is not None:
+    logpath = eventlog.handler_factories[0].instance.baseFilename
+    logfolder = os.path.split(logpath)[0]
+    logfile = os.path.join(logfolder, AUDITLOG)
+else:
+    logfile = AUDITLOG
 
 logger = logging.getLogger(PROJECTNAME)
+logger.info('Start logging audit information to ' + AUDITLOG)
+
+handler = logging.FileHandler(logfile)
+formatter = logging.Formatter(LOGFORMAT)
+handler.setFormatter(formatter)
+logger.addHandler(handler)
+
+
+def log_info(*args, **kwargs):
+    """Log information to a file handling access from multiple instances.
+    This code was taken from ZEO/ClientStorage.py.
+    """
+    # try to lock the logfile then write to the logfile
+    lockfilename = logfile + '.lock'
+    n = 0
+
+    while 1:
+        try:
+            lock = zc.lockfile.LockFile(lockfilename)
+            logger.info(*args, **kwargs)
+            lock.close()
+        except zc.lockfile.LockError:
+            time.sleep(0.01)
+            n += 1
+            if n > 60000:
+                raise
+        else:
+            break
+
+    return

--- a/src/collective/fingerpointing/subscribers/iterate_logger.py
+++ b/src/collective/fingerpointing/subscribers/iterate_logger.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from collective.fingerpointing.config import AUDIT_MESSAGE
 from collective.fingerpointing.interfaces import IFingerPointingSettings
-from collective.fingerpointing.logger import logger
+from collective.fingerpointing.logger import log_info
 from collective.fingerpointing.utils import get_request_information
 from plone import api
 from plone.api.exc import InvalidParameterError
@@ -38,4 +38,4 @@ def iterate_logger(event):
             extras = 'object={0} baseline={1}'.format(
                 event.object, event.baseline)
 
-        logger.info(AUDIT_MESSAGE.format(user, ip, action, extras))
+        log_info(AUDIT_MESSAGE.format(user, ip, action, extras))

--- a/src/collective/fingerpointing/subscribers/lifecycle_logger.py
+++ b/src/collective/fingerpointing/subscribers/lifecycle_logger.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from collective.fingerpointing.config import AUDIT_MESSAGE
 from collective.fingerpointing.interfaces import IFingerPointingSettings
-from collective.fingerpointing.logger import logger
+from collective.fingerpointing.logger import log_info
 from collective.fingerpointing.utils import get_request_information
 from plone import api
 from plone.api.exc import InvalidParameterError
@@ -35,4 +35,4 @@ def lifecycle_logger(obj, event):
             action = 'object removed'
             extras = 'object={0}'.format(obj)
 
-        logger.info(AUDIT_MESSAGE.format(user, ip, action, extras))
+        log_info(AUDIT_MESSAGE.format(user, ip, action, extras))

--- a/src/collective/fingerpointing/subscribers/pas_logger.py
+++ b/src/collective/fingerpointing/subscribers/pas_logger.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from collective.fingerpointing.config import AUDIT_MESSAGE
 from collective.fingerpointing.interfaces import IFingerPointingSettings
-from collective.fingerpointing.logger import logger
+from collective.fingerpointing.logger import log_info
 from collective.fingerpointing.utils import get_request_information
 from plone import api
 from plone.api.exc import InvalidParameterError
@@ -37,4 +37,4 @@ def pas_logger(event):
             action = 'user removed'
             extras = 'object={0}'.format(event.principal)
 
-        logger.info(AUDIT_MESSAGE.format(user, ip, action, extras))
+        log_info(AUDIT_MESSAGE.format(user, ip, action, extras))

--- a/src/collective/fingerpointing/subscribers/registry_logger.py
+++ b/src/collective/fingerpointing/subscribers/registry_logger.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from collective.fingerpointing.config import AUDIT_MESSAGE
 from collective.fingerpointing.interfaces import IFingerPointingSettings
-from collective.fingerpointing.logger import logger
+from collective.fingerpointing.logger import log_info
 from collective.fingerpointing.utils import get_request_information
 from plone import api
 from plone.api.exc import InvalidParameterError
@@ -25,4 +25,4 @@ def registry_logger(event):
             action = 'record modified'
             extras = 'object={0} value={1}'.format(event.record, event.record.value)
 
-        logger.info(AUDIT_MESSAGE.format(user, ip, action, extras))
+        log_info(AUDIT_MESSAGE.format(user, ip, action, extras))


### PR DESCRIPTION
This pr adds a new registry setting "audit_logfile" which adds an extra logHandler to the "collective.fingerpointing" logger if configured.

You need to restart your instance to apply this setting.