### PR TITLE
Remove unused plone.directives.form dependency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.0a2 (unreleased)
 ------------------
 
+- Remove unused plone.directives.form dependency which pulled in grok packages.
+  [vangheem]
+
 - Audit information is now logged into a file named `audit.log` instead of inside the standard `event.log`.
   [jochum]
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ setup(
     install_requires=[
         'plone.api',
         'plone.app.registry',
-        'plone.directives.form',
         'plone.registry',
         'Products.CMFCore',
         'Products.CMFPlone >=4.2',

--- a/src/collective/fingerpointing/interfaces.py
+++ b/src/collective/fingerpointing/interfaces.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from collective.fingerpointing import _
-from plone.directives import form
 from zope import schema
 from zope.interface import Interface
 
@@ -10,7 +9,7 @@ class IBrowserLayer(Interface):
     """A layer specific for this add-on product."""
 
 
-class IFingerPointingSettings(form.Schema):
+class IFingerPointingSettings(Interface):
 
     """Schema for the control panel form."""
 


### PR DESCRIPTION
This dependency pulls in grok packages that people might not want.