### PR TITLE
#18 Reorder the "View Audit log" entry above "Log out" in portal_actions/user.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog
 ------------------
 
 - The "View Audit log" action appears now before the "Log out" one (fixes `#18`_).
-  [pcdummy]
+  [pcdummy, hvelarde]
 
 - Use the main_template for the logview.
   [pcdummy]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.0b2 (unreleased)
 ------------------
 
+- The "View Audit log" action appears now before the "Log out" one (fixes `#18`_).
+  [pcdummy]
+
 - Use the main_template for the logview.
   [pcdummy]
 
@@ -17,7 +20,7 @@ Changelog
 - Add a view for the audit.log file `@@fingerpointing-audit-log` and link it to portal_actions.
   [pcdummy, hvelarde]
 
-- Make control panel configlet accesible to Site Administrator role (closes `#18`_).
+- Make control panel configlet accesible to Site Administrator role (closes `#15`_).
   [hvelarde]
 
 - Avoid `ComponentLookupError` when removing a Plone site (fixes `#4`_).
@@ -44,4 +47,5 @@ Changelog
 .. _`#1`: https://github.com/collective/collective.fingerpointing/issues/1
 .. _`#2`: https://github.com/collective/collective.fingerpointing/issues/2
 .. _`#4`: https://github.com/collective/collective.fingerpointing/issues/4
+.. _`#15`: https://github.com/collective/collective.fingerpointing/issues/15
 .. _`#18`: https://github.com/collective/collective.fingerpointing/issues/18

--- a/src/collective/fingerpointing/profiles/default/actions.xml
+++ b/src/collective/fingerpointing/profiles/default/actions.xml
@@ -2,7 +2,7 @@
 <object name="portal_actions" meta_type="Plone Actions Tool"
     xmlns:i18n="http://xml.zope.org/namespaces/i18n">
   <object name="user" meta_type="CMF Action Category">
-    <object name="audit-log" meta_type="CMF Action" i18n:domain="collective.fingerpointing">
+    <object name="audit-log" meta_type="CMF Action" i18n:domain="collective.fingerpointing" insert-before="logout">
       <property name="title" i18n:translate="">View Audit Log</property>
       <property name="description" i18n:translate=""></property>
       <property name="url_expr">string:${portal_url}/@@fingerpointing-audit-log</property>

--- a/src/collective/fingerpointing/profiles/default/metadata.xml
+++ b/src/collective/fingerpointing/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2</version>
+  <version>3</version>
 </metadata>

--- a/src/collective/fingerpointing/profiles/uninstall/actions.xml
+++ b/src/collective/fingerpointing/profiles/uninstall/actions.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<object name="portal_actions" meta_type="Plone Actions Tool">
+  <object name="user" meta_type="CMF Action Category">
+    <object name="audit-log" meta_type="CMF Action" remove="true" />
+  </object>
+</object>

--- a/src/collective/fingerpointing/upgrades/configure.zcml
+++ b/src/collective/fingerpointing/upgrades/configure.zcml
@@ -1,3 +1,4 @@
 <configure xmlns="http://namespaces.zope.org/zope">
   <include package=".v2" />
+  <include package=".v3" />
 </configure>

--- a/src/collective/fingerpointing/upgrades/v3/__init__.py
+++ b/src/collective/fingerpointing/upgrades/v3/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+from collective.fingerpointing.config import PROJECTNAME
+from collective.fingerpointing.logger import logger
+
+
+def update_user_actions(setup_tool):
+    """Update user actions."""
+    profile = 'profile-{0}:default'.format(PROJECTNAME)
+    setup_tool.runImportStepFromProfile(profile, 'actions')
+    logger.info('User actions updated.')

--- a/src/collective/fingerpointing/upgrades/v3/configure.zcml
+++ b/src/collective/fingerpointing/upgrades/v3/configure.zcml
@@ -1,0 +1,20 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    xmlns:i18n="http://namespaces.zope.org/i18n"
+    i18n_domain="collective.fingerpointing">
+
+  <genericsetup:upgradeSteps
+      source="2"
+      destination="3"
+      profile="collective.fingerpointing:default">
+
+    <genericsetup:upgradeStep
+        title="Update user actions"
+        description="Move view audit log action before log out."
+        handler=".update_user_actions"
+        />
+
+  </genericsetup:upgradeSteps>
+
+</configure>


### PR DESCRIPTION
And add an uninstaller for the action.

Signed-off-by: Rene Jochum <rene@jochums.at>

closes #18 