### PR TITLE
Issue 38 - Use object representation to log life cycle events

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 1.0b4 (unreleased)
 ------------------
 
+- Use object representation to log life cycle events;
+  this fixes an issue with Archetypes-based objects being dumped to the log (refs. `#8`_ and fixes `#38`_).
+  [hvelarde]
+
 - Package is now compatible with Plone 5.0 and Plone 5.1.
   [hvelarde]
 
@@ -84,7 +88,9 @@ Changelog
 .. _`#1`: https://github.com/collective/collective.fingerpointing/issues/1
 .. _`#2`: https://github.com/collective/collective.fingerpointing/issues/2
 .. _`#4`: https://github.com/collective/collective.fingerpointing/issues/4
+.. _`#8`: https://github.com/collective/collective.fingerpointing/issues/8
 .. _`#15`: https://github.com/collective/collective.fingerpointing/issues/15
 .. _`#18`: https://github.com/collective/collective.fingerpointing/issues/18
 .. _`#25`: https://github.com/collective/collective.fingerpointing/issues/25
 .. _`#30`: https://github.com/collective/collective.fingerpointing/issues/30
+.. _`#38`: https://github.com/collective/collective.fingerpointing/issues/38

--- a/src/collective/fingerpointing/subscribers/lifecycle_logger.py
+++ b/src/collective/fingerpointing/subscribers/lifecycle_logger.py
@@ -28,12 +28,12 @@ def lifecycle_logger(obj, event):
 
         if IObjectCreatedEvent.providedBy(event):
             action = 'create'
-            extras = 'object={0}'.format(obj)
+            extras = 'object={0}'.format(repr(obj))
         if IObjectModifiedEvent.providedBy(event):
             action = 'modify'
-            extras = 'object={0}'.format(obj)
+            extras = 'object={0}'.format(repr(obj))
         if IObjectRemovedEvent.providedBy(event):
             action = 'remove'
-            extras = 'object={0}'.format(obj)
+            extras = 'object={0}'.format(repr(obj))
 
         log_info(AUDIT_MESSAGE.format(user, ip, action, extras))

--- a/src/collective/fingerpointing/testing.py
+++ b/src/collective/fingerpointing/testing.py
@@ -21,7 +21,7 @@ else:
     from plone.app.contenttypes.testing import PLONE_APP_CONTENTTYPES_FIXTURE as PLONE_FIXTURE
 
 
-PLONE_VERSION = api.env.plone_version()
+IS_PLONE_5 = api.env.plone_version().startswith('5')
 
 
 class Fixture(PloneSandboxLayer):

--- a/src/collective/fingerpointing/tests/test_lifecycle_subscriber.py
+++ b/src/collective/fingerpointing/tests/test_lifecycle_subscriber.py
@@ -38,7 +38,7 @@ class LifeCycleSubscribersTestCase(unittest.TestCase):
                 ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=modify object=<ATFolder at foo>'),
             )
 
-        with LogCapture(level=INFO) as log:
+        with LogCapture('collective.fingerpointing', level=INFO) as log:
             api.content.create(self.folder, 'Folder', 'foo')
             log.check(*expected)
 
@@ -55,7 +55,7 @@ class LifeCycleSubscribersTestCase(unittest.TestCase):
             )
 
         api.content.create(self.folder, 'Folder', 'foo')
-        with LogCapture(level=INFO) as log:
+        with LogCapture('collective.fingerpointing', level=INFO) as log:
             api.content.delete(self.folder['foo'])
             log.check(*expected)
 

--- a/src/collective/fingerpointing/tests/test_lifecycle_subscriber.py
+++ b/src/collective/fingerpointing/tests/test_lifecycle_subscriber.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 """Tests for lifecycle subscriber.
 
-Events are slightly different among Plone 4 and Plone 5. Also, Plone 5
-content types have different names.
+Events are slightly different among Archetypes and Dexterity.
+Also, Dexterity content types have different names.
 """
 from collective.fingerpointing.config import PROJECTNAME
 from collective.fingerpointing.testing import INTEGRATION_TESTING
-from collective.fingerpointing.testing import PLONE_VERSION
+from collective.fingerpointing.testing import IS_PLONE_5
 from logging import INFO
 from plone import api
 from testfixtures import LogCapture
@@ -25,38 +25,73 @@ class LifeCycleSubscribersTestCase(unittest.TestCase):
         with api.env.adopt_roles(['Manager']):
             self.folder = api.content.create(self.portal, 'Folder', 'folder')
 
-    def test_object_created(self):
-        if PLONE_VERSION >= '5.0':
+    def test_file_lifecicle(self):
+        if IS_PLONE_5:
             expected = (
-                ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=create object=<Folder at foo>'),
-                ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=modify object=<Folder at folder>'),
+                ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=create object=<File at foo>'),
+                ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=modify object=<Folder at /plone/folder>'),
+                ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=remove object=<File at /plone/folder/foo>'),
+                ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=modify object=<Folder at /plone/folder>'),
             )
         else:
             expected = (
-                ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=create object=<ATFolder at foo>'),
-                ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=modify object=<ATFolder at folder>'),
-                ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=modify object=<ATFolder at foo>'),
+                ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=create object=<ATFile at /plone/folder/foo>'),
+                ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=modify object=<ATFolder at /plone/folder>'),
+                ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=modify object=<ATFile at /plone/folder/foo>'),
+                ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=remove object=<ATFile at /plone/folder/foo>'),
+                ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=modify object=<ATFolder at /plone/folder>'),
             )
 
         with LogCapture('collective.fingerpointing', level=INFO) as log:
-            api.content.create(self.folder, 'Folder', 'foo')
+            obj = api.content.create(self.folder, 'File', 'foo')
+            obj.reindexObject()
+            api.content.delete(obj)
             log.check(*expected)
 
-    def test_object_removed(self):
-        if PLONE_VERSION >= '5.0':
+    def test_folder_lifecicle(self):
+        if IS_PLONE_5:
             expected = (
-                ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=remove object=<Folder at foo>'),
-                ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=modify object=<Folder at folder>'),
+                ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=create object=<Folder at foo>'),
+                ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=modify object=<Folder at /plone/folder>'),
+                ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=remove object=<Folder at /plone/folder/foo>'),
+                ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=modify object=<Folder at /plone/folder>'),
             )
         else:
             expected = (
-                ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=remove object=<ATFolder at foo>'),
-                ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=modify object=<ATFolder at folder>'),
+                ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=create object=<ATFolder at /plone/folder/foo>'),
+                ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=modify object=<ATFolder at /plone/folder>'),
+                ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=modify object=<ATFolder at /plone/folder/foo>'),
+                ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=remove object=<ATFolder at /plone/folder/foo>'),
+                ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=modify object=<ATFolder at /plone/folder>'),
             )
 
-        api.content.create(self.folder, 'Folder', 'foo')
         with LogCapture('collective.fingerpointing', level=INFO) as log:
-            api.content.delete(self.folder['foo'])
+            obj = api.content.create(self.folder, 'Folder', 'foo')
+            obj.reindexObject()
+            api.content.delete(obj)
+            log.check(*expected)
+
+    def test_image_lifecicle(self):
+        if IS_PLONE_5:
+            expected = (
+                ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=create object=<Image at foo>'),
+                ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=modify object=<Folder at /plone/folder>'),
+                ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=remove object=<Image at /plone/folder/foo>'),
+                ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=modify object=<Folder at /plone/folder>'),
+            )
+        else:
+            expected = (
+                ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=create object=<ATImage at /plone/folder/foo>'),
+                ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=modify object=<ATFolder at /plone/folder>'),
+                ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=modify object=<ATImage at /plone/folder/foo>'),
+                ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=remove object=<ATImage at /plone/folder/foo>'),
+                ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=modify object=<ATFolder at /plone/folder>'),
+            )
+
+        with LogCapture('collective.fingerpointing', level=INFO) as log:
+            obj = api.content.create(self.folder, 'Image', 'foo')
+            obj.reindexObject()
+            api.content.delete(obj)
             log.check(*expected)
 
     def test_susbcriber_ignored_when_package_not_installed(self):
@@ -67,5 +102,6 @@ class LifeCycleSubscribersTestCase(unittest.TestCase):
         with api.env.adopt_roles(['Manager']):
             qi.uninstallProducts(products=[PROJECTNAME])
 
-        api.content.create(self.folder, 'Folder', 'foo')
-        api.content.delete(self.folder['foo'])
+        obj = api.content.create(self.folder, 'Folder', 'foo')
+        obj.reindexObject()
+        api.content.delete(obj)

--- a/src/collective/fingerpointing/tests/test_pas_subscriber.py
+++ b/src/collective/fingerpointing/tests/test_pas_subscriber.py
@@ -1,11 +1,7 @@
 # -*- coding: utf-8 -*-
-"""Tests for lifecycle subscriber.
-
-Log output is slightly different among Plone 4 and Plone 5.
-"""
+"""Tests for lifecycle subscriber."""
 from collective.fingerpointing.config import PROJECTNAME
 from collective.fingerpointing.testing import INTEGRATION_TESTING
-from collective.fingerpointing.testing import PLONE_VERSION
 from logging import INFO
 from plone import api
 from Products.PlonePAS.events import UserLoggedInEvent
@@ -28,29 +24,16 @@ class PasSubscribersTestCase(unittest.TestCase):
         self.request = self.layer['request']
 
     def test_user_login(self):
-        if PLONE_VERSION >= '5.0':
-            expected = (
-                ('plone.protect', 'INFO', 'auto rotating keyring _system'),
-                ('plone.protect', 'INFO', 'auto rotating keyring _forms'),
-                ('plone.protect', 'INFO', 'auto rotating keyring _anon'),
-                ('plone.protect', 'INFO', 'auto rotating keyring _system'),
-                ('plone.protect', 'INFO', 'auto rotating keyring _forms'),
-                ('plone.protect', 'INFO', 'auto rotating keyring _anon'),
-                ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=login '),
-            )
-        else:
-            expected = (
-                ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=login '),
-            )
-
         event = UserLoggedInEvent(self.request)
-        with LogCapture(level=INFO) as log:
+        with LogCapture('collective.fingerpointing', level=INFO) as log:
             notify(event)
-            log.check(*expected)
+            log.check(
+                ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=login '),
+            )
 
     def test_user_logout(self):
         event = UserLoggedOutEvent(self.request)
-        with LogCapture(level=INFO) as log:
+        with LogCapture('collective.fingerpointing', level=INFO) as log:
             notify(event)
             log.check(
                 ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=logout '),
@@ -58,7 +41,7 @@ class PasSubscribersTestCase(unittest.TestCase):
 
     def test_user_created(self):
         event = PrincipalCreated('foo')
-        with LogCapture(level=INFO) as log:
+        with LogCapture('collective.fingerpointing', level=INFO) as log:
             notify(event)
             log.check(
                 ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=create principal=foo'),
@@ -66,7 +49,7 @@ class PasSubscribersTestCase(unittest.TestCase):
 
     def test_user_removed(self):
         event = PrincipalDeleted('foo')
-        with LogCapture(level=INFO) as log:
+        with LogCapture('collective.fingerpointing', level=INFO) as log:
             notify(event)
             log.check(
                 ('collective.fingerpointing', 'INFO', 'user=test ip=127.0.0.1 action=remove principal=foo'),

--- a/src/collective/fingerpointing/tests/test_registry_subscriber.py
+++ b/src/collective/fingerpointing/tests/test_registry_subscriber.py
@@ -19,7 +19,7 @@ class RegistrySubscribersTestCase(unittest.TestCase):
         self.portal = self.layer['portal']
 
     def test_record_modified(self):
-        with LogCapture(level=INFO) as log:
+        with LogCapture('collective.fingerpointing', level=INFO) as log:
             record = IDiscussionSettings.__identifier__ + '.globally_enabled'
             api.portal.set_registry_record(record, False)
             log.check(

--- a/src/collective/fingerpointing/tests/test_view.py
+++ b/src/collective/fingerpointing/tests/test_view.py
@@ -27,12 +27,10 @@ class LogViewTestCase(unittest.TestCase):
             self.portal.restrictedTraverse('@@fingerpointing-audit-log')
 
     def test_log_tail(self):
-        from logging import INFO
         from Products.PlonePAS.events import UserLoggedOutEvent
-        from testfixtures import LogCapture
         from zope.event import notify
-        # verify user logged out event is first on log (newer entries first)
         event = UserLoggedOutEvent(self.request)
-        with LogCapture(level=INFO):
-            notify(event)
-            self.assertIn('action=logout', self.view.get_audit_log)
+        notify(event)
+        audit_log = self.view.get_audit_log.split('\n')
+        # user logged out event is first on log (newer entries first)
+        self.assertIn('user=test ip=127.0.0.1 action=logout', audit_log[0])


### PR DESCRIPTION
This fixes an issue with Archetypes-based objects being dumped to the log.

Refs. #8 
Fixes #38 