### PR TITLE
Avoid ComponentLookupError when plonectl adduser

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 1.1b2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Avoid ComponentLookupError when plonectl adduser.
+  [jianaijun]
 
 
 1.1b1 (2016-07-07)

--- a/src/collective/fingerpointing/subscribers/pas_logger.py
+++ b/src/collective/fingerpointing/subscribers/pas_logger.py
@@ -10,6 +10,7 @@ from Products.PluggableAuthService.interfaces.events import IPrincipalCreatedEve
 from Products.PluggableAuthService.interfaces.events import IPrincipalDeletedEvent
 from Products.PluggableAuthService.interfaces.events import IUserLoggedInEvent
 from Products.PluggableAuthService.interfaces.events import IUserLoggedOutEvent
+from zope.component.interfaces import ComponentLookupError
 
 
 def pas_logger(event):
@@ -19,7 +20,7 @@ def pas_logger(event):
     try:
         record = IFingerPointingSettings.__identifier__ + '.audit_pas'
         audit_pas = api.portal.get_registry_record(record)
-    except InvalidParameterError:
+    except (InvalidParameterError, ComponentLookupError):
         return
 
     if audit_pas:


### PR DESCRIPTION
Traceback (most recent call last):
  File "/home/free/Plone/zinstance/parts/instance/bin/interpreter", line 355, in <module>
    exec(_val)
  File "<string>", line 1, in <module>
  File "/home/free/Plone/buildout-cache/eggs/Products.PlonePAS-5.0.11-py2.7.egg/Products/PlonePAS/pas.py", line 99, in _doAddUser
    retval = _old_doAddUser(login, password, roles, domains)
  File "/home/free/Plone/buildout-cache/eggs/Products.PluggableAuthService-1.11.0-py2.7.egg/Products/PluggableAuthService/PluggableAuthService.py", line 1025, in _doAddUser
    notify(PrincipalCreated(user))
  File "/home/free/Plone/buildout-cache/eggs/zope.event-3.5.2-py2.7.egg/zope/event/__init__.py", line 31, in notify
    subscriber(event)
  File "/home/free/Plone/buildout-cache/eggs/zope.component-3.9.5-py2.7.egg/zope/component/event.py", line 24, in dispatch
    zope.component.subscribers(event, None)
  File "/home/free/Plone/buildout-cache/eggs/zope.component-3.9.5-py2.7.egg/zope/component/_api.py", line 136, in subscribers
    return sitemanager.subscribers(objects, interface)
  File "/home/free/Plone/buildout-cache/eggs/zope.component-3.9.5-py2.7.egg/zope/component/registry.py", line 321, in subscribers
    return self.adapters.subscribers(objects, provided)
  File "/home/free/Plone/buildout-cache/eggs/zope.interface-3.6.7-py2.7-linux-x86_64.egg/zope/interface/adapter.py", line 585, in subscribers
    subscription(_objects)
  File "/home/free/Plone/buildout-cache/eggs/collective.fingerpointing-1.1b1-py2.7.egg/collective/fingerpointing/subscribers/pas_logger.py", line 21, in pas_logger
    audit_pas = api.portal.get_registry_record(record)
  File "<string>", line 2, in get_registry_record
  File "/home/free/Plone/buildout-cache/eggs/plone.api-1.5-py2.7.egg/plone/api/validation.py", line 70, in wrapped
    return f(_args, **kwargs)
  File "/home/free/Plone/buildout-cache/eggs/plone.api-1.5-py2.7.egg/plone/api/portal.py", line 275, in get_registry_record
    registry = getUtility(IRegistry)
  File "/home/free/Plone/buildout-cache/eggs/zope.component-3.9.5-py2.7.egg/zope/component/_api.py", line 169, in getUtility
    raise ComponentLookupError(interface, name)
