### PR TITLE
Fix the audit.log path (fixes: #45) and make the rotating configureable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Changelog
 1.1b2 (unreleased)
 ------------------
 
-- Fix audit.log path when other logghandlers are installed and make rotating
-  configureable, through zope.conf. [rene]
+- Make log rotating configurable using the `zope-conf-additional` option.
+  [rene, hvelarde]
 
 
 1.1b1 (2016-07-07)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 1.1b2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix audit.log path when other logghandlers are installed and make rotating
+  configureable, through zope.conf. [rene]
 
 
 1.1b1 (2016-07-07)

--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ Installation
 
 To enable this package in a buildout-based installation:
 
-#. Edit your buildout.cfg and add add the following to it:
+Edit your buildout.cfg and add the following to it:
 
 .. code-block:: ini
 
@@ -55,22 +55,25 @@ To enable this package in a buildout-based installation:
     eggs =
         collective.fingerpointing
 
+By default, ``collective.fingerpointing`` logs audit events to the event log only.
+   To enable logging to a separate file use the following configuration:
+
+.. code-block:: ini
+
     [instance]
     zope-conf-additional +=
-      <product-config collective.fingerpointing>
-        audit-log ${buildout:directory}/var/log/audit.log
-        audit-log-max-size 10240
-        audit-log-old-files 30
-      </product-config>
+        <product-config collective.fingerpointing>
+            audit-log ${buildout:directory}/var/log/audit.log
+            audit-log-max-size 10240
+            audit-log-old-files 30
+        </product-config>
 
-The values in `zope-conf-additional`:
-
-  - `audit-log`: Absolute path of the audit.log logfile
-  - `audit-log-max-size`: Rotate at a size of x bytes, can be 0 to never rotate.
-  - `audit-log-old-files`: Keep X rotated log files on hand.
-
-Without these lines in zope.conf `fingerpointing` will try to detect the path of the eventlog and use that one,
-if that also fails it will use `./audit.log`.
+audit-log
+    The filename of the audit log. Defaults to none.
+audit-log-max-size
+    Maximum size of audit log file. Enables log rotation.
+audit-log-old-files
+    Number of previous log files to retain when log rotation is enabled. Defaults to 1.
 
 After updating the configuration you need to run ''bin/buildout'', which will take care of updating your system.
 
@@ -95,21 +98,21 @@ Finger Pointing will start logging the selected events:
 .. code-block:: console
 
     # bin/instance fg
-    2016-03-01 17:29:29 INFO ZServer HTTP server started at Tue Mar  1 17:29:29 2016
-            Hostname: 0.0.0.0
-            Port: 8080
-    2016-03-01 17:29:31 INFO collective.fingerpointing Start logging audit information to audit.log
-    2016-03-01 17:29:34 INFO Plone OpenID system packages not installed, OpenID support not available
-    2016-03-01 17:29:37 INFO Zope Ready to handle requests
-    2016-03-01 17:31:40 INFO collective.fingerpointing user=admin ip=127.0.0.1 action=logged out
-    2016-03-01 17:31:49 INFO collective.fingerpointing user=admin ip=127.0.0.1 action=logged in
+    2016-09-26 15:23:36 INFO ZServer HTTP server started at Mon Sep 26 15:23:36 2016
+        Hostname: 0.0.0.0
+        Port: 8080
+    2016-09-26 15:23:41 INFO collective.fingerpointing Logging audit information to /home/hvelarde/collective/fingerpointing/var/log/audit.log
+    2016-09-26 15:23:49 INFO Plone OpenID system packages not installed, OpenID support not available
+    2016-09-26 15:23:56 INFO Zope Ready to handle requests
+    2016-09-26 15:24:19 INFO collective.fingerpointing user=admin ip=127.0.0.1 action=logout
+    2016-09-26 15:24:28 INFO collective.fingerpointing user=admin ip=127.0.0.1 action=login
 
 These events are also logged in `var/log/audit.log`:
 
 .. code-block:: console
 
-    2016-03-01 17:31:40,813 - INFO - user=admin ip=127.0.0.1 action=logged out
-    2016-03-01 17:31:49,678 - INFO - user=admin ip=127.0.0.1 action=logged in
+    2016-09-26 15:24:19,717 - INFO - user=admin ip=127.0.0.1 action=logout
+    2016-09-26 15:24:28,415 - INFO - user=admin ip=127.0.0.1 action=login
 
 An audit log view is available in the user menu to users with the `collective.fingerpointing: View Audit Log` permission:
 
@@ -121,4 +124,17 @@ An audit log view is available in the user menu to users with the `collective.fi
 
     The Finger Pointing audit log view.
 
-Audit log files are rotated automatically every day at midnight and up to 30 days are maintained in backup.
+If you specify no audit log file you'll see a warning;
+however, audit events will be normally logged to the event log:
+
+.. code-block:: console
+
+    # bin/instance fg
+    2016-09-26 15:58:32 INFO ZServer HTTP server started at Mon Sep 26 15:58:32 2016
+        Hostname: 0.0.0.0
+        Port: 8080
+    2016-09-26 15:58:35 WARNING collective.fingerpointing No audit log file specified; audit log view will be disabled
+    2016-09-26 15:58:40 INFO Plone OpenID system packages not installed, OpenID support not available
+    2016-09-26 15:58:45 INFO Zope Ready to handle requests
+    2016-09-26 15:58:48 INFO collective.fingerpointing user=admin ip=127.0.0.1 action=logout
+    2016-09-26 15:58:54 INFO collective.fingerpointing user=admin ip=127.0.0.1 action=login

--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,23 @@ To enable this package in a buildout-based installation:
     eggs =
         collective.fingerpointing
 
+    [instance]
+    zope-conf-additional +=
+      <product-config collective.fingerpointing>
+        audit-log ${buildout:directory}/var/log/audit.log
+        audit-log-max-size 10240
+        audit-log-old-files 30
+      </product-config>
+
+The values in `zope-conf-additional`:
+
+  - `audit-log`: Absolute path of the audit.log logfile
+  - `audit-log-max-size`: Rotate at a size of x bytes, can be 0 to never rotate.
+  - `audit-log-old-files`: Keep X rotated log files on hand.
+
+Without these lines in zope.conf `fingerpointing` will try to detect the path of the eventlog and use that one,
+if that also fails it will use `./audit.log`.
+
 After updating the configuration you need to run ''bin/buildout'', which will take care of updating your system.
 
 Go to the 'Site Setup' page in a Plone site and click on the 'Add-ons' link.

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -25,6 +25,14 @@ return-status-codes = True
 flake8 = True
 flake8-ignore = E501,P001,T000
 
+[instance]
+zope-conf-additional +=
+    <product-config collective.fingerpointing>
+        audit-log ${buildout:directory}/var/log/audit.log
+        audit-log-max-size 0
+        audit-log-old-files 1
+    </product-config>
+
 [i18ndude]
 recipe = zc.recipe.egg
 eggs = i18ndude

--- a/src/collective/fingerpointing/browser/logview.pt
+++ b/src/collective/fingerpointing/browser/logview.pt
@@ -21,7 +21,11 @@
     </metal:title>
 
     <metal:content-core metal:fill-slot="content-core">
-      <pre tal:content="view/get_audit_log" />
+      <pre tal:condition="view/available" tal:content="view/get_audit_log" />
+
+      <p tal:condition="not:view/available" i18n:translate="">
+        No audit log file specified; audit log view is disabled.
+      </p>
     </metal:content-core>
   </body>
 </html>

--- a/src/collective/fingerpointing/browser/logview.py
+++ b/src/collective/fingerpointing/browser/logview.py
@@ -15,6 +15,9 @@ class LogView(BrowserView):
     def render(self):
         return self.index()
 
+    def available(self):
+        return LOGFILE is not None
+
     def tail(self, f, n=100):
         """Return the last n lines of a file.
         See: http://stackoverflow.com/a/280083/644075

--- a/src/collective/fingerpointing/config.py
+++ b/src/collective/fingerpointing/config.py
@@ -1,5 +1,12 @@
 # -*- coding: utf-8 -*-
-PROJECTNAME = 'collective.fingerpointing'
+from App.config import getConfiguration
 
-AUDITLOG = 'audit.log'
+
+PROJECTNAME = 'collective.fingerpointing'
 AUDIT_MESSAGE = u'user={0} ip={1} action={2} {3}'
+LOG_FORMAT = '%(asctime)s - %(levelname)s - %(message)s'
+
+# read configuration from zope.conf
+zopeConf = getConfiguration()
+product_config = getattr(zopeConf, 'product_config', {})
+fingerpointing_config = product_config.get(PROJECTNAME, {})

--- a/src/collective/fingerpointing/logger.py
+++ b/src/collective/fingerpointing/logger.py
@@ -8,6 +8,7 @@ import time
 import zc.lockfile
 
 logger = logging.getLogger(PROJECTNAME)
+logger.setLevel(logging.INFO)
 
 logfile = fingerpointing_config.get('audit-log', None)
 if logfile is None:

--- a/src/collective/fingerpointing/testing.py
+++ b/src/collective/fingerpointing/testing.py
@@ -28,7 +28,16 @@ class Fixture(PloneSandboxLayer):
 
     defaultBases = (PLONE_FIXTURE,)
 
+    # XXX: this can probably be done in a different way
+    def _configure_audit_log(self):
+        """Fake configuration for collective.fingerpointing as tests
+        expect an audit.log file to be set.
+        """
+        from collective.fingerpointing.config import fingerpointing_config
+        fingerpointing_config['audit-log'] = '/tmp/audit.log'
+
     def setUpZope(self, app, configurationContext):
+        self._configure_audit_log()
         import collective.fingerpointing
         self.loadZCML(package=collective.fingerpointing)
 

--- a/src/collective/fingerpointing/tests/test_view.py
+++ b/src/collective/fingerpointing/tests/test_view.py
@@ -31,7 +31,7 @@ class LogViewTestCase(unittest.TestCase):
         # we have at least one log file to process
         self.assertGreaterEqual(len(audit_log_files), 1)
         # the first file is the current audit log
-        self.assertEqual('./audit.log', audit_log_files[0])
+        self.assertEqual('/tmp/audit.log', audit_log_files[0])
 
     def test_log_tail(self):
         from Products.PlonePAS.events import UserLoggedOutEvent


### PR DESCRIPTION
We don't want rotating of the audit.log so we added a option to disable that (defaults to on - rotate).

Also we have Mailinglogger installed which breaks the path detection.

Signed-off-by: Rene Jochum <rene@jochums.at>