### PR TITLE
Do not fail running plone-compile-resources together with fingerpointing.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.8.1 (unreleased)
 ------------------
 
+- Do not fail running ``plone-compile-resources`` together with fingerpointing installed in Plone 5.2.
+  [jensens]
+
 - Completed french translations.
   [gbastien]
 

--- a/src/collective/fingerpointing/logger.py
+++ b/src/collective/fingerpointing/logger.py
@@ -4,6 +4,7 @@ from collective.fingerpointing.config import LOG_FORMAT
 from collective.fingerpointing.config import PROJECTNAME
 
 import logging
+import logging.handlers
 import time
 import zc.lockfile
 


### PR DESCRIPTION
If installed in Plone 5.2.
See also #97 