### PR TITLE
In ``workflow_logger`` display full path of object instead just object id

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 1.8.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- In ``workflow_logger`` display full path of object instead just object id.
+  [gbastien]
 
 
 1.8.1 (2019-11-22)

--- a/src/collective/fingerpointing/subscribers/workflow_logger.py
+++ b/src/collective/fingerpointing/subscribers/workflow_logger.py
@@ -18,7 +18,7 @@ def workflow_logger(event):
 
     action = 'workflow transition'
     extras = 'object={0} transition={1}'.format(
-        event.object,
+        repr(event.object),
         event.action,
     )
     log_info(AUDIT_MESSAGE.format(user, ip, action, extras))

--- a/src/collective/fingerpointing/tests/test_workflow_subscriber.py
+++ b/src/collective/fingerpointing/tests/test_workflow_subscriber.py
@@ -31,15 +31,15 @@ class WorkflowSubscribersTestCase(unittest.TestCase, QIBBB):
 
         if IS_PLONE_5:
             expected = (
-                ('collective.fingerpointing', 'INFO', u'user=test_user_1_ ip=None action=workflow transition object=<NewsItem at foo> transition=submit'),  # noqa: E501
-                ('collective.fingerpointing', 'INFO', u'user=test_user_1_ ip=None action=workflow transition object=<NewsItem at foo> transition=publish'),  # noqa: E501
-                ('collective.fingerpointing', 'INFO', u'user=test_user_1_ ip=None action=workflow transition object=<NewsItem at foo> transition=retract'),  # noqa: E501
+                ('collective.fingerpointing', 'INFO', u'user=test_user_1_ ip=None action=workflow transition object=<NewsItem at /plone/foo> transition=submit'),  # noqa: E501
+                ('collective.fingerpointing', 'INFO', u'user=test_user_1_ ip=None action=workflow transition object=<NewsItem at /plone/foo> transition=publish'),  # noqa: E501
+                ('collective.fingerpointing', 'INFO', u'user=test_user_1_ ip=None action=workflow transition object=<NewsItem at /plone/foo> transition=retract'),  # noqa: E501
             )
         else:
             expected = (
-                ('collective.fingerpointing', 'INFO', u'user=test_user_1_ ip=None action=workflow transition object=<ATNewsItem at foo> transition=submit'),  # noqa: E501
-                ('collective.fingerpointing', 'INFO', u'user=test_user_1_ ip=None action=workflow transition object=<ATNewsItem at foo> transition=publish'),  # noqa: E501
-                ('collective.fingerpointing', 'INFO', u'user=test_user_1_ ip=None action=workflow transition object=<ATNewsItem at foo> transition=retract'),  # noqa: E501
+                ('collective.fingerpointing', 'INFO', u'user=test_user_1_ ip=None action=workflow transition object=<ATNewsItem at /plone/foo> transition=submit'),  # noqa: E501
+                ('collective.fingerpointing', 'INFO', u'user=test_user_1_ ip=None action=workflow transition object=<ATNewsItem at /plone/foo> transition=publish'),  # noqa: E501
+                ('collective.fingerpointing', 'INFO', u'user=test_user_1_ ip=None action=workflow transition object=<ATNewsItem at /plone/foo> transition=retract'),  # noqa: E501
             )
 
         with LogCapture('collective.fingerpointing', level=INFO) as log:


### PR DESCRIPTION
This is related to #102 

Please review and merge ;-)

Gauthier